### PR TITLE
feat: promote docker image to prod acr

### DIFF
--- a/.github/scripts/promote_acr.py
+++ b/.github/scripts/promote_acr.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+def run(cmd):
+    """Run a command and return its stdout."""
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+    return result.stdout.strip()
+
+
+def main(nonprod_acr, prod_acr, image_repo, image_tag, nonprod_user, nonprod_pass, prod_user, prod_pass):
+    nonprod_login = nonprod_acr if '.' in nonprod_acr else f"{nonprod_acr}.azurecr.io"
+
+    # Check if tag exists in prod registry
+    try:
+        tags_output = run([
+            "az", "acr", "repository", "show-tags",
+            "--name", prod_acr,
+            "--repository", image_repo,
+            "--output", "tsv"
+        ])
+        if image_tag in tags_output.splitlines():
+            print(f"Image {image_repo}:{image_tag} already exists in {prod_acr}")
+            return
+    except subprocess.CalledProcessError:
+        # Repository may not exist yet; proceed with import
+        pass
+
+    print(f"Promoting {image_repo}:{image_tag} from {nonprod_acr} to {prod_acr}")
+
+    # Authenticate to the target registry so the import command can push the image
+    run(["az", "acr", "login", "--name", prod_acr, "--username", prod_user, "--password", prod_pass])
+
+    # Import the image into prod
+    run([
+        "az", "acr", "import",
+        "--name", prod_acr,
+        "--source", f"{nonprod_login}/{image_repo}:{image_tag}",
+        "--image", f"{image_repo}:{image_tag}",
+        "--username", nonprod_user,
+        "--password", nonprod_pass,
+    ])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 9:
+        print(
+            "Usage: promote_acr.py <nonprod_acr> <prod_acr> <image_repo> <image_tag> "
+            "<nonprod_user> <nonprod_pass> <prod_user> <prod_pass>"
+        )
+        sys.exit(1)
+    main(*sys.argv[1:])

--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -229,20 +229,18 @@ jobs:
           image_repo: ${{ env.AZURE_CONTAINER_REGISTRY }}
           image_path: ${{ env.REPO_NAME }}
           docker_tag: ${{ env.DOCKER_TAG }}
-      # - name: 🔄 Promote Docker Image to Prod
-      #   if: ${{ inputs.docker_tag != '' && startsWith(inputs.environment, 'prod') }}
-      #   uses: Tractor-Supply-Ecommerce/pipeline-commons-library/.github/actions/docker-promote@main
-      #   with:
-      #     acr_nonprod: ${{ secrets.ACR_NONPROD }}
-      #     acr_name: ${{ env.AZURE_CONTAINER_NAME }}
-      #     acr_username_nonprod: ${{ secrets.ACR_USERNAME_NONPROD }}
-      #     acr_password_nonprod: ${{ secrets.ACR_PASSWORD_NONPROD }}
-      #     acr_username_prod: ${{ secrets.ACR_USERNAME_PROD }}
-      #     acr_password_prod: ${{ secrets.ACR_PASSWORD_PROD }}
-      #     environment: ${{ inputs.environment }}
-      #     image_repo: ${{ env.AZURE_CONTAINER_REGISTRY }}
-      #     image_path: ${{ env.REPO_NAME }}
-      #     docker_tag: ${{ env.DOCKER_TAG }}
+      - name: 🔄 Promote Docker Image to Prod
+        if: ${{ inputs.docker_tag != '' && startsWith(inputs.environment, 'prod') }}
+        run: |
+          python "$GITHUB_WORKSPACE/.github/scripts/promote_acr.py" \
+            "${{ secrets.ACR_NONPROD }}" \
+            "${{ env.AZURE_CONTAINER_NAME }}" \
+            "${{ env.REPO_NAME }}" \
+            "${{ env.DOCKER_TAG }}" \
+            "${{ secrets.ACR_USERNAME_NONPROD }}" \
+            "${{ secrets.ACR_PASSWORD_NONPROD }}" \
+            "${{ secrets.ACR_USERNAME_PROD }}" \
+            "${{ secrets.ACR_PASSWORD_PROD }}"
 
 
   deploy:

--- a/.github/workflows/tsc-cicd-workflow.yaml
+++ b/.github/workflows/tsc-cicd-workflow.yaml
@@ -223,6 +223,18 @@ jobs:
           image_repo: ${{ env.AZURE_CONTAINER_REGISTRY }}
           image_path: ${{ env.REPO_NAME }}
           docker_tag: ${{ env.DOCKER_TAG }}
+      - name: 🔄 Promote Docker Image to Prod
+        if: ${{ env.DOCKER_TAG != '' && startsWith(env.DEPLOY_ENV, 'prod') }}
+        run: |
+          python "$GITHUB_WORKSPACE/.github/scripts/promote_acr.py" \
+            "${{ secrets.ACR_NONPROD }}" \
+            "${{ env.AZURE_CONTAINER_NAME }}" \
+            "${{ env.REPO_NAME }}" \
+            "${{ env.DOCKER_TAG }}" \
+            "${{ secrets.ACR_USERNAME_NONPROD }}" \
+            "${{ secrets.ACR_PASSWORD_NONPROD }}" \
+            "${{ secrets.ACR_USERNAME_PROD }}" \
+            "${{ secrets.ACR_PASSWORD_PROD }}"
       - name: 🔍 Print CI step outputs
         run: |
           echo "docker_tag=${{ steps.set-tag.outputs.docker_tag }}"


### PR DESCRIPTION
## Summary
- replace shell-based image promotion with Python script
- invoke Python promotion step during prod deployments in reusable workflows
- run promotion script from repository root using absolute path

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile .github/scripts/promote_acr.py`


------
https://chatgpt.com/codex/tasks/task_e_68910e7f226483258cea2330b34a37b4