### PR TITLE
fix: authenticate when checking prod tags

### DIFF
--- a/.github/scripts/promote_acr.py
+++ b/.github/scripts/promote_acr.py
@@ -38,7 +38,9 @@ def main(nonprod_acr, prod_acr, image_repo, image_tag, nonprod_user, nonprod_pas
             "az", "acr", "repository", "show-tags",
             "--name", prod_acr,
             "--repository", image_repo,
-            "--output", "tsv"
+            "--output", "tsv",
+            "--username", prod_user,
+            "--password", prod_pass,
         ])
         if image_tag in tags_output.splitlines():
             print(f"Image {image_repo}:{image_tag} already exists in {prod_acr}")


### PR DESCRIPTION
## Summary
- supply registry credentials when calling `az acr repository show-tags`

## Testing
- `python3 -m py_compile .github/scripts/promote_acr.py`


------
https://chatgpt.com/codex/tasks/task_e_68913d41b6e883259c95f6b45b76fc1f