### PR TITLE
feat: ensure az login before import

### DIFF
--- a/.github/scripts/promote_acr.py
+++ b/.github/scripts/promote_acr.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import shutil
 import subprocess
 import sys
@@ -25,22 +26,79 @@ def run(cmd):
         raise
 
 
-def main(nonprod_acr, prod_acr, image_repo, image_tag, nonprod_user, nonprod_pass, prod_user, prod_pass):
+def main(
+    nonprod_acr,
+    prod_acr,
+    image_repo,
+    image_tag,
+    nonprod_user,
+    nonprod_pass,
+    prod_user,
+    prod_pass,
+    prod_subscription,
+):
     if not shutil.which("az"):
         print("Azure CLI not found. Please install az before running this script.")
         sys.exit(1)
+
+    # Ensure the CLI is authenticated; fall back to service principal login if needed
+    try:
+        subprocess.run(
+            ["az", "account", "show", "--output", "none"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        client_id = os.environ.get("AZURE_CLIENT_ID")
+        tenant_id = os.environ.get("AZURE_TENANT_ID")
+        client_secret = os.environ.get("AZURE_CLIENT_SECRET")
+
+        if not all([client_id, tenant_id, client_secret]):
+            print(
+                "Azure CLI not logged in and service principal credentials are missing.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        run(
+            [
+                "az",
+                "login",
+                "--service-principal",
+                "-u",
+                client_id,
+                "-p",
+                client_secret,
+                "--tenant",
+                tenant_id,
+            ]
+        )
+
+    run(["az", "account", "set", "--subscription", prod_subscription])
 
     nonprod_login = nonprod_acr if '.' in nonprod_acr else f"{nonprod_acr}.azurecr.io"
 
     # Check if tag exists in prod registry
     try:
         tags_output = run([
-            "az", "acr", "repository", "show-tags",
-            "--name", prod_acr,
-            "--repository", image_repo,
-            "--output", "tsv",
-            "--username", prod_user,
-            "--password", prod_pass,
+            "az",
+            "acr",
+            "repository",
+            "show-tags",
+            "--name",
+            prod_acr,
+            "--repository",
+            image_repo,
+            "--output",
+            "tsv",
+            "--username",
+            prod_user,
+            "--password",
+            prod_pass,
+            "--subscription",
+            prod_subscription,
         ])
         if image_tag in tags_output.splitlines():
             print(f"Image {image_repo}:{image_tag} already exists in {prod_acr}")
@@ -52,24 +110,49 @@ def main(nonprod_acr, prod_acr, image_repo, image_tag, nonprod_user, nonprod_pas
     print(f"Promoting {image_repo}:{image_tag} from {nonprod_acr} to {prod_acr}")
 
     # Authenticate to the target registry so the import command can push the image
-    run(["az", "acr", "login", "--name", prod_acr, "--username", prod_user, "--password", prod_pass])
+    run(
+        [
+            "az",
+            "acr",
+            "login",
+            "--name",
+            prod_acr,
+            "--username",
+            prod_user,
+            "--password",
+            prod_pass,
+            "--subscription",
+            prod_subscription,
+        ]
+    )
 
     # Import the image into prod
-    run([
-        "az", "acr", "import",
-        "--name", prod_acr,
-        "--source", f"{nonprod_login}/{image_repo}:{image_tag}",
-        "--image", f"{image_repo}:{image_tag}",
-        "--username", nonprod_user,
-        "--password", nonprod_pass,
-    ])
+    run(
+        [
+            "az",
+            "acr",
+            "import",
+            "--name",
+            prod_acr,
+            "--source",
+            f"{nonprod_login}/{image_repo}:{image_tag}",
+            "--image",
+            f"{image_repo}:{image_tag}",
+            "--username",
+            nonprod_user,
+            "--password",
+            nonprod_pass,
+            "--subscription",
+            prod_subscription,
+        ]
+    )
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 9:
+    if len(sys.argv) != 10:
         print(
             "Usage: promote_acr.py <nonprod_acr> <prod_acr> <image_repo> <image_tag> "
-            "<nonprod_user> <nonprod_pass> <prod_user> <prod_pass>"
+            "<nonprod_user> <nonprod_pass> <prod_user> <prod_pass> <prod_subscription>",
         )
         sys.exit(1)
     main(*sys.argv[1:])

--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -79,6 +79,14 @@ on:
         required: false
       AZURE_SUBSCRIPTION_ID:
         required: false
+      AZURE_CLIENT_ID_PROD:
+        required: false
+      AZURE_CLIENT_SECRET_PROD:
+        required: false
+      AZURE_TENANT_ID_PROD:
+        required: false
+      AZURE_SUBSCRIPTION_ID_PROD:
+        required: false
       DOCKER_USER:
         required: false
       DOCKER_PASS:
@@ -155,7 +163,7 @@ jobs:
         if: ${{ steps.trusted.outputs.appType == 'nodejs' && steps.trusted.outputs.buildDeploy == 'true' }}
         id: set-tag
         run: |
-          tag="${{ inputs.dockerTag }}"
+          tag="${{ inputs.docker_tag }}"
           if [ -z "$tag" ]; then
             formatted_branch="${GITHUB_REF_NAME//\//.}"
             tag="${formatted_branch}.${GITHUB_RUN_NUMBER}"
@@ -232,6 +240,10 @@ jobs:
       - name: 🔄 Promote Docker Image to Prod
         if: ${{ env.DOCKER_TAG != '' && startsWith(env.DEPLOY_ENV, 'prod')  && steps.trusted.outputs.appType == 'maven'  }}
         shell: bash
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_PROD }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_PROD }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_PROD }}
         run: |
           ls -lart $GITHUB_WORKSPACE/*
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
@@ -243,7 +255,8 @@ jobs:
             "${{ secrets.ACR_USERNAME_NONPROD }}" \
             "${{ secrets.ACR_PASSWORD_NONPROD }}" \
             "${{ secrets.ACR_USERNAME_PROD }}" \
-            "${{ secrets.ACR_PASSWORD_PROD }}"
+            "${{ secrets.ACR_PASSWORD_PROD }}" \
+            "${{ secrets.AZURE_SUBSCRIPTION_ID_PROD }}"
 
   deploy:
     name: 🐳 ${{ inputs.docker_tag }}


### PR DESCRIPTION
## Summary
- ensure promote_acr runs az login with service principal if needed
- set Azure subscription when provided to target correct registry
- respect `docker_tag` workflow input when setting image tag
- target prod subscription explicitly during promotion and pass prod credentials in workflow

## Testing
- `python -m py_compile .github/scripts/promote_acr.py`
- `pip install pyyaml` *(fails: Cannot connect to proxy)*


------
https://chatgpt.com/codex/tasks/task_e_68913fb5df0c8325acf4a7c93192c937