### PR TITLE
Ensure docker tag input applies to all app types

### DIFF
--- a/.github/actions/docker-publish/action.yaml
+++ b/.github/actions/docker-publish/action.yaml
@@ -19,7 +19,7 @@ inputs:
   image_path:
     required: true
   docker_tag:
-    required: true
+    required: false
 
 outputs:
   docker_tag:
@@ -42,8 +42,14 @@ runs:
       id: set-tag
       shell: bash
       run: |
-        formatted_branch="${GITHUB_REF_NAME//\//.}"
-        tag="${formatted_branch}.${GITHUB_RUN_NUMBER}"
+        if [ -n "${{ inputs.docker_tag }}" ]; then
+          tag="${{ inputs.docker_tag }}"
+        elif [ -n "$DOCKER_TAG" ]; then
+          tag="$DOCKER_TAG"
+        else
+          formatted_branch="${GITHUB_REF_NAME//\//.}"
+          tag="${formatted_branch}.${GITHUB_RUN_NUMBER}"
+        fi
         echo "docker_tag=$tag" >> $GITHUB_OUTPUT
         echo "DOCKER_TAG=$tag" >> $GITHUB_ENV
         ls -lrt **

--- a/.github/actions/trusted-config/action.yaml
+++ b/.github/actions/trusted-config/action.yaml
@@ -12,6 +12,9 @@ inputs:
   environment:
     description: Optional override environment
     required: false
+  docker_tag:
+    description: Optional Docker image tag
+    required: false
 
 outputs:
   environment:
@@ -124,7 +127,9 @@ runs:
         echo "AZURE_CONTAINER_REGISTRY=${ACR_NAME}.azurecr.io" >> $GITHUB_ENV
         echo "AZURE_CONTAINER_NAME=$ACR_NAME" >> $GITHUB_ENV
 
-        if [[ -z "$DOCKER_TAG" ]]; then
+        if [[ -n "${{ inputs.docker_tag }}" ]]; then
+          echo "DOCKER_TAG=${{ inputs.docker_tag }}" >> $GITHUB_ENV
+        elif [[ -z "$DOCKER_TAG" ]]; then
           formatted_branch="${GITHUB_REF_NAME//\//.}"
           echo "DOCKER_TAG=${formatted_branch}.${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
         fi

--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -151,6 +151,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           environment: ${{ inputs.environment }}
+          docker_tag: ${{ inputs.docker_tag }}
           secrets_json: ${{ toJson(secrets) }}
 
 #      - name: ☕ Setup Java
@@ -160,7 +161,7 @@ jobs:
 #          java-version: ${{ steps.trusted.outputs.javaVersion }}
 
       - name: 🔖 Set Docker Tag
-        if: ${{ steps.trusted.outputs.appType == 'nodejs' && steps.trusted.outputs.buildDeploy == 'true' }}
+        if: ${{ steps.trusted.outputs.buildDeploy == 'true' }}
         id: set-tag
         run: |
           


### PR DESCRIPTION
## Summary
- Allow trusted-config action to accept an explicit `docker_tag` and export it to the environment or fall back to a branch-based tag
- Teach docker-publish to honor a provided tag or existing `DOCKER_TAG` before generating a fallback
- Forward `docker_tag` input through deploy-env workflow to keep tagging consistent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920aa4d8b8832595217ad9bdb0440a