### PR TITLE
refactor: simplify ACR promotion login

### DIFF
--- a/.github/scripts/promote_acr.py
+++ b/.github/scripts/promote_acr.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 """Promote a container image from non-prod ACR to prod ACR.
 
+This script mirrors the authentication logic used in the composite
+`docker-publish` action. Instead of performing an `az login` and setting
+subscriptions, it authenticates directly to each registry using the
+provided credentials (falling back to ``az acr login`` when no credentials
+are supplied).
+
 Steps performed:
-1. Log in using the non-prod service principal (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,
-   AZURE_TENANT_ID).
-2. Select the non-prod subscription and pull the image from the non-prod registry.
-3. Retag the image for prod.
-4. Log in using the prod service principal (AZURE_CLIENT_ID_PROD,
-   AZURE_CLIENT_SECRET_PROD, AZURE_TENANT_ID_PROD).
-5. Select the prod subscription and push the image to the prod registry.
+1. Log in to the non-prod registry and pull the specified image.
+2. Retag the image for prod.
+3. Log in to the prod registry and push the retagged image.
 """
 
-import os
-import shutil
 import subprocess
 import sys
 
@@ -37,26 +37,15 @@ def run(cmd):
         raise
 
 
-def login_service_principal(client_id, client_secret, tenant_id):
-    """Authenticate with a specific service principal."""
-    if not all([client_id, client_secret, tenant_id]):
-        print("Missing service principal credentials", file=sys.stderr)
-        sys.exit(1)
-
-    print(f"🔐 Logging in with service principal {client_id}")
-    run(
-        [
-            "az",
-            "login",
-            "--service-principal",
-            "-u",
-            client_id,
-            "-p",
-            client_secret,
-            "--tenant",
-            tenant_id,
-        ]
-    )
+def login_registry(registry, username=None, password=None, name=None):
+    """Log in to an ACR registry using docker credentials or `az acr login`."""
+    if username and password:
+        print(f"🔐 Logging in to {registry} with Docker")
+        run(["docker", "login", registry, "-u", username, "-p", password])
+    else:
+        name = name or registry
+        print(f"🔐 Logging in to {name} via az acr")
+        run(["az", "acr", "login", "--name", name])
 
 
 def main(
@@ -68,45 +57,16 @@ def main(
     nonprod_pass,
     prod_user,
     prod_pass,
-    nonprod_subscription,
-    prod_subscription,
 ):
-    if not shutil.which("az"):
-        print("Azure CLI not found. Please install az before running this script.")
-        sys.exit(1)
-
-    # Step 1: authenticate to non-prod
-    login_service_principal(
-        os.environ.get("AZURE_CLIENT_ID"),
-        os.environ.get("AZURE_CLIENT_SECRET"),
-        os.environ.get("AZURE_TENANT_ID"),
-    )
-
     nonprod_reg = nonprod_acr if "." in nonprod_acr else f"{nonprod_acr}.azurecr.io"
     prod_reg = prod_acr if "." in prod_acr else f"{prod_acr}.azurecr.io"
 
-    # Step 2: select non-prod subscription
-    print(f"🔧 Selecting non-prod subscription {nonprod_subscription}")
-    run(["az", "account", "set", "--subscription", nonprod_subscription])
-
-    # Step 3: log in to non-prod registry and pull image
+    # Step 1: log in to non-prod registry and pull image
+    login_registry(nonprod_reg, nonprod_user, nonprod_pass, nonprod_acr)
     print(f"📥 Pulling {nonprod_reg}/{image_repo}:{image_tag}")
-    run(
-        [
-            "az",
-            "acr",
-            "login",
-            "--name",
-            nonprod_acr,
-            "--username",
-            nonprod_user,
-            "--password",
-            nonprod_pass,
-        ]
-    )
     run(["docker", "pull", f"{nonprod_reg}/{image_repo}:{image_tag}"])
 
-    # Step 4: retag for prod
+    # Step 2: retag for prod
     print("🏷️ Retagging for prod")
     run(
         [
@@ -117,39 +77,17 @@ def main(
         ]
     )
 
-    # Step 5: authenticate and switch to prod
-    login_service_principal(
-        os.environ.get("AZURE_CLIENT_ID_PROD"),
-        os.environ.get("AZURE_CLIENT_SECRET_PROD"),
-        os.environ.get("AZURE_TENANT_ID_PROD"),
-    )
-    print(f"🔧 Selecting prod subscription {prod_subscription}")
-    run(["az", "account", "set", "--subscription", prod_subscription])
-
-    # Step 6: log in to prod registry and push the image
+    # Step 3: log in to prod registry and push the image
+    login_registry(prod_reg, prod_user, prod_pass, prod_acr)
     print(f"🚀 Pushing to {prod_reg}/{image_repo}:{image_tag}")
-    run(
-        [
-            "az",
-            "acr",
-            "login",
-            "--name",
-            prod_acr,
-            "--username",
-            prod_user,
-            "--password",
-            prod_pass,
-        ]
-    )
     run(["docker", "push", f"{prod_reg}/{image_repo}:{image_tag}"])
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 11:
+    if len(sys.argv) != 9:
         print(
             "Usage: promote_acr.py <nonprod_acr> <prod_acr> <image_repo> <image_tag> "
-            "<nonprod_user> <nonprod_pass> <prod_user> <prod_pass> "
-            "<nonprod_subscription> <prod_subscription>",
+            "<nonprod_user> <nonprod_pass> <prod_user> <prod_pass>",
         )
         sys.exit(1)
     main(*sys.argv[1:])


### PR DESCRIPTION
## Summary
- simplify promote_acr script to login directly to ACR like docker-publish action
- remove subscription switching and service principal login

## Testing
- `python -m py_compile .github/scripts/promote_acr.py`


------
https://chatgpt.com/codex/tasks/task_e_68927f53afdc83258905653d6d85dfa0