### PR TITLE
docs: document separate Splunk tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ This repository deploys Helm charts via GitHub Actions. Splunk HEC tokens are in
 
 Configure the following secrets in your repository settings:
 
+For React applications:
+
 - `SPLUNK_TOKEN_PROD` – used for production deployments
 - `SPLUNK_TOKEN_NONPROD` – used for non‑production deployments
 
-These values are passed to the deploy workflows and written into Helm values at runtime.
+For microservices or other Maven-based applications:
+
+- `SPLUNK_TOKEN_PROD_MS` – used for production deployments
+- `SPLUNK_TOKEN_NONPROD_MS` – used for non‑production deployments
+
+Use the token pair that matches your application type; the deploy workflows
+inject the appropriate value into the Helm chart at runtime.


### PR DESCRIPTION
## Summary
- note separate Splunk HEC tokens for React vs Maven-based services

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68929cc4c43c8325a51bf96ebc468d3b